### PR TITLE
feat: load grid set from external URL

### DIFF
--- a/docs/documentation_user/04_navigation-overview.md
+++ b/docs/documentation_user/04_navigation-overview.md
@@ -5,7 +5,7 @@
 Once a user has been created and some grid set has been imported, AsTeRICS Grid always opens the last used user in the "main view", which looks like Figure 1:
 
 ![main view](./img/main_en.jpg)
-*Figure 1: Main view (desktop view on the left, mobile view on the right)*
+_Figure 1: Main view (desktop view on the left, mobile view on the right)_
 
 The elements have this functionality:
 
@@ -21,29 +21,30 @@ The elements have this functionality:
 10. **Help**: find the AsTeRICS Grid user manuel, the ARASAAC tutorial or video tutorials
 11. [**Editing on**](04_navigation-overview.md#editing-on): edit the layout of the grid, add new elements, actions for grid elements
 12. [**Input options**](09_input-options.md): Options about how to select grid elements (e.g. click, hover, scanning)
-13. **Fullscreen**: hide the sidebar and the bar on the top, only showing the current grid 
-14. **Lock**: lock the screen in order to prevent unintended input or changes beside using and navigating the grid 
+13. **Fullscreen**: hide the sidebar and the bar on the top, only showing the current grid
+14. **Lock**: lock the screen in order to prevent unintended input or changes beside using and navigating the grid
 15. **Grid**: demo grid consisting of some grid elements which are navigating to other grids if selected (possible for those which show the grey symbol in the upper right corner)
 16. [**Search function**](04_navigation-overview.md#search-function) (not shown in the Figure): Search for elements in the grid set. You can also use `Ctrl + F` on the keyboard.
 
 ## Search function
+
 Clicking on "Search" in the main view or pressing `Ctrl + F` opens a search dialog. It can also be opened in fullscreen mode by an [element navigation action](08_actions.md#navigate-to-other-grid):
 
 ![change user view](./img/search-dialog.png)
-*Search dialog and search results*
+_Search dialog and search results_
 
 These are the parts of the search dialog:
+
 1. **search term**: text input field for the search term
 2. **result image**: directly navigates to the selected element and highlights it. Keyboard shortcut for first search result: `[Enter]`
 3. **result path**: navigates to the selected element step-by-step by highlighting the path beginning from the home grid. Keyboard shortcut for first search result: `[Ctrl + Enter]`
-
 
 ## Editing on
 
 Clicking on Button "Editing on" (Figure 1.11) opens the edit view where a grid can be adapted, see Figure 2:
 
 ![edit view](./img/edit_en.jpg)
-*Figure 2: Edit view (desktop view on the left, mobile view on the right)*
+_Figure 2: Edit view (desktop view on the left, mobile view on the right)_
 
 The following elements are available in the edit view:
 
@@ -60,12 +61,12 @@ In the "Change User" view it's possible to switch between users or login an exis
 
 ![change user view](./img/login_en.jpg)
 
-*Figure 5: "Change user" view (desktop view on the left, mobile view on the right)*
+_Figure 5: "Change user" view (desktop view on the left, mobile view on the right)_
 
 The following elements are available in the change users view:
 
 1. Open or close the navigation sidebar
-2. **Active offline user**: the currently active user is recognizable by a black user symbol and the word "active" next to the username. The active user is the user whose grids and configuration are currently used and shown in all other views. 
+2. **Active offline user**: the currently active user is recognizable by a black user symbol and the word "active" next to the username. The active user is the user whose grids and configuration are currently used and shown in all other views.
 3. **Inactive online user**: The little cloud symbol indicates an [online user](01_terms.md#user) and the gray user symbol that he is currently inactive, meaning that the user's grids are currently not used.
 4. **Inactive offline user**: The gray user symbol without a cloud indicates an inactive [offline user](01_terms.md#user)
 5. **Open**: sets the user "active" and opens the main view, showing the user's grid(s). Sets all other users inactive, there is always only one active user.
@@ -74,13 +75,17 @@ The following elements are available in the change users view:
 8. **Login with other user**: put in username and password of an existing online user in order to add it to the current device. In order to create a new online or offline user, follow one of the links below.
 9. **Remember checkbox**: if checked, the newly logged in online user will be saved to the device and listed in the list of users in the current user view. If unchecked the user will only be opened temporarily and no user data will be saved on the device (recommended for logging in on foreign devices).
 
+### Sharing users via URL
+
+You can share an online user by sending a link such as `https://grid.asterics.eu/?user=username&password=pw`. Everyone with the link can log in and edit the user's configuration. If the link contains `&uselocalcopy=true`, an offline user is created with a copy of the online user's data so changes do not affect the original user. Note that the credentials remain visible in the URL and can still be used to access the original account.
+
 ## Add online user
 
 In view "add online user" it's possible to register a new online user, Figure 6:
 
 ![add online user view](./img/register_online_en.jpg)
 
-*Figure 6: Add online user view - register*
+_Figure 6: Add online user view - register_
 
 ### Synchronization states
 
@@ -102,53 +107,58 @@ In view "add offline user" it's possible to add a new [offline user](01_terms.md
 
 ![add offline user view](./img/add_offline_en.jpg)
 
-*Figure 7: Add offline user view*
+_Figure 7: Add offline user view_
 
 ## Shortcuts
 
 Note that for macOs `⌘` (command key) can be used instead of `Ctrl`.
 
 These are the global keyboard shortcuts available in AsTeRICS Grid:
-* `Ctrl + Alt + Arrow Right`: change to the next stored user
-* `Ctrl + Backspace`: navigate to the last grid
-* `Ctrl + Pos1`: navigate to the main/home grid
-* `Ctrl + F`: open dialog for searching elements
+
+-   `Ctrl + Alt + Arrow Right`: change to the next stored user
+-   `Ctrl + Backspace`: navigate to the last grid
+-   `Ctrl + Pos1`: navigate to the main/home grid
+-   `Ctrl + F`: open dialog for searching elements
 
 ### Shortcuts in user mode
+
 The shortcuts available in user mode (normal grid view) are listed below.
 
-* `Ctrl + C`: copy current sentence from collection element to clipboard (as image).
+-   `Ctrl + C`: copy current sentence from collection element to clipboard (as image).
 
 ### Shortcuts in edit mode
+
 The shortcuts available in edit mode are listed below.
 
-- `Ctrl + left mouse clicks`: select multiple elements, one after the other
-- `Shift + left mouse clicks`: select multiple connected elements
-- `Escape`: unselect all elements
-- `Ctrl + E`: edit selected element
-- `Ctrl + C`: copy selected elements to clipboard
-- `Ctrl + X`: cut selected elements (copy to clipboard and delete from current grid)
-- `Ctrl + V`: paste elements from clipboard. Elements are pasted at the location of the last interaction (you can click/tap to a free space before pasting). If multiple pasted elements aren't fitting at the current location, they are pasted below the existing elements.
-- `Ctrl + A`: selects all elements
-- `Ctrl + D`: duplicates selected elements
-- `Ctrl + H`: hide / unhide selected elements
-- `Ctrl + I`: create a new element
-- `Ctrl + Shift + I`: create many new elements
-- `Delete`: deletes selected elements
-- `Ctrl + Z`: Undo
-- `Ctrl + Shift + Z`: Redo
+-   `Ctrl + left mouse clicks`: select multiple elements, one after the other
+-   `Shift + left mouse clicks`: select multiple connected elements
+-   `Escape`: unselect all elements
+-   `Ctrl + E`: edit selected element
+-   `Ctrl + C`: copy selected elements to clipboard
+-   `Ctrl + X`: cut selected elements (copy to clipboard and delete from current grid)
+-   `Ctrl + V`: paste elements from clipboard. Elements are pasted at the location of the last interaction (you can click/tap to a free space before pasting). If multiple pasted elements aren't fitting at the current location, they are pasted below the existing elements.
+-   `Ctrl + A`: selects all elements
+-   `Ctrl + D`: duplicates selected elements
+-   `Ctrl + H`: hide / unhide selected elements
+-   `Ctrl + I`: create a new element
+-   `Ctrl + Shift + I`: create many new elements
+-   `Delete`: deletes selected elements
+-   `Ctrl + Z`: Undo
+-   `Ctrl + Shift + Z`: Redo
 
 #### Layout shortcuts
-- `Ctrl + ArrowUp`: move all elements up
-- `Ctrl + ArrowRight`: move all elements right
-- `Ctrl + ArrowDown`: move all elements down
-- `Ctrl + ArrowLeft`: move all elements left
+
+-   `Ctrl + ArrowUp`: move all elements up
+-   `Ctrl + ArrowRight`: move all elements right
+-   `Ctrl + ArrowDown`: move all elements down
+-   `Ctrl + ArrowLeft`: move all elements left
 
 #### Transfer properties
-- `Ctrl + Shift + A`: directly transfer all properties of selected element (`A` like all)
-- `Ctrl + Shift + C`: directly transfer appearance properties of selected element (`C` like color)
-- `Ctrl + Shift + P`: transfer custom properties of selected element (`P` like properties)
-- `Escape`: cancel property transfer mode
-- `Enter`: apply property transfer to selected elements
+
+-   `Ctrl + Shift + A`: directly transfer all properties of selected element (`A` like all)
+-   `Ctrl + Shift + C`: directly transfer appearance properties of selected element (`C` like color)
+-   `Ctrl + Shift + P`: transfer custom properties of selected element (`P` like properties)
+-   `Escape`: cancel property transfer mode
+-   `Enter`: apply property transfer to selected elements
 
 [Back to Overview](README.md)

--- a/docs/documentation_user/07a_word-forms.md
+++ b/docs/documentation_user/07a_word-forms.md
@@ -2,16 +2,18 @@
 
 [Back to Overview](README.md)
 
-For simple communication boards it's sufficient to use static labels (in different languages) for grid elements. However, for more advanced communicators "word forms" can be used in order to allow grammatically correct communication. 
+For simple communication boards it's sufficient to use static labels (in different languages) for grid elements. However, for more advanced communicators "word forms" can be used in order to allow grammatically correct communication.
 
 ## General
+
 Word forms can be defined for each element in the [dialogue for editing grid elements](07_grid-elements.md). The tab `Word forms` allows to define and edit word forms (see Figure 1).
 
 ![edit view](./img/word-forms-modal.png)
 
-*Figure 1: Dialogue for defining and editing word forms*
+_Figure 1: Dialogue for defining and editing word forms_
 
 The dialogue in Figure 1 shows the following options:
+
 1. **Language**: (optional) language of the new word form
 2. **Tags**: (optional) tags assigned to the new word form (e.g. `1.PERS` or `PLURAL`)
 3. **Word form**: the value of the new word form
@@ -29,37 +31,48 @@ The dialogue in Figure 1 shows the following options:
 15. **Down button**: moves the word form down within the list
 
 ## Word form actions
+
 Once word forms are defined for different elements, they can be used and selected using the action type `change word forms` in tab `Actions` of the modal for editing a grid element (see Figure 1). Figure 2 shows the possibilities for configuring this action.
 
 ![edit view](./img/action-word-forms.png)
-*Figure 2: Configuring an action of type "Change word forms".*
+_Figure 2: Configuring an action of type "Change word forms"._
 
 ### General function
+
 In general most action types for `change word forms` allow it to define tags (Figure 2 number 2) which are added to an internal (hidden) list of current tags, if the action is performed.
 
 **Example 1**: for example there could be the following elements within a grid:
-* **Element "You"**: has action `change word forms` with tag `2.PERS`.
-* **Element "Past"**: has action `change word forms` with tag `PAST`.
-* **Element "to be"**: has defined various word forms with tags like `am [1.PERS, PRESENT]`, `are [2.PERS, PRESENT]`, `were [2.PERS, PAST]`.
+
+-   **Element "You"**: has action `change word forms` with tag `2.PERS`.
+-   **Element "Past"**: has action `change word forms` with tag `PAST`.
+-   **Element "to be"**: has defined various word forms with tags like `am [1.PERS, PRESENT]`, `are [2.PERS, PRESENT]`, `were [2.PERS, PAST]`.
 
 Now using these elements would work as follows:
+
 1. **Select element "You"**: tag `2.PERS` is added to internal list, word forms are changed in order to match this tag -> element "to be" is changed to `are` because it's the first word form including the tag `2.PERS`
 2. **Select element "Past"**: tag `PAST` is added to internal list, which now includes `2.PERS, PAST`. Word forms are changed to match these tags -> element "to be" is changed to `were` because it's the first word form including the tags `2.PERS` and `PAST`.
 
 ### Action types
+
 These are the action types for `change word forms` (Figure 2 number 1):
-* **Change word form in grid elements**: changes the labels of grid elements to the word form that best matches the current internal list of tags.
-* **Change word form in collection element**: changes the last element in the collection element to the word form that best matches the current internal list of tags.
-* **Change word form everywhere**: changes word forms both within grid elements and within the last word of the collect element.
-* **Change this element to next word form**: doesn't use tags for selecting word forms, but simply iterates through the list of word forms defined within this element. *Example usage:* word forms contain a list of names, clicking on the element several times allows to select one of the names.
-* **Reset currently displayed word forms**: resets the word forms, clears the tags currently stored within the internal list. This is done automatically each time an element is selected which doesn't include any `change word form` action.
+
+-   **Change word form in grid elements**: changes the labels of grid elements to the word form that best matches the current internal list of tags.
+-   **Change word form in collection element**: changes the last element in the collection element to the word form that best matches the current internal list of tags.
+-   **Change word form everywhere**: changes word forms both within grid elements and within the last word of the collect element.
+-   **Change this element to next word form**: doesn't use tags for selecting word forms, but simply iterates through the list of word forms defined within this element. _Example usage:_ word forms contain a list of names, clicking on the element several times allows to select one of the names.
+-   **Reset currently displayed word forms**: resets the word forms, clears the tags currently stored within the internal list. This is done automatically each time an element is selected which doesn't include any `change word form` action.
 
 Figure 2 number 3 shows an additional option `Toggle tags on selecting it multiple times`. If this option is activated, selecting this element several times in a row, toggles the tags of this action in the internal list. So in example 1 (see above) selecting the element "Past" multiple times would add and remove the tag `PAST` from the internal list, causing to toggle between the words `are` and `were`.
 
-The action type `change this element to next word form` also has an option `secondary action type`. If selected, the tags of the current word form are used for a secondary action. *Example usage:* an element has 2 word forms `I [1.PERS]` and `You [2.PERS]`. Iterating through these values using `change this element to next word form` with `secondary action type` = `change word form in grid elements` will cause changing all other grid elements to `1.PERS` after selecting `I` and to `2.PERS` after selecting `You`.
+The action type `change this element to next word form` also has an option `secondary action type`. If selected, the tags of the current word form are used for a secondary action. _Example usage:_ an element has 2 word forms `I [1.PERS]` and `You [2.PERS]`. Iterating through these values using `change this element to next word form` with `secondary action type` = `change word form in grid elements` will cause changing all other grid elements to `1.PERS` after selecting `I` and to `2.PERS` after selecting `You`.
 
 ## Example configuration
+
 A grid configuration including examples for all word form features can be tested here:
 <a href="https://grid.asterics.eu/?gridset_filename=grammar-demos.grd.json">Grid configuration with word form examples</a>. It contains examples for all different action types of `change word forms`.
+
+It is also possible to load grid sets directly from external URLs by using the `gridset_url` parameter, for example:
+`https://grid.asterics.eu/?gridset_url=https://example.com/mygrid.obz`.
+Files with the extensions `.grd.json`, `.obf` or `.obz` are supported.
 
 [Back to Overview](README.md)

--- a/src/js/service/urlParamService.js
+++ b/src/js/service/urlParamService.js
@@ -8,9 +8,12 @@ urlParamService.params = {
     PARAM_RESET_DATABASE: 'reset',
     PARAM_USE_GRIDSET_FILENAME: 'gridset_filename',
     PARAM_USE_GRIDSET_URL: 'gridset_url',
-    PARAM_ELEMENT_HIGHLIGHT_IDS: "highlightIds",
-    PARAM_LOCKED: "locked",
-    PARAM_FULLSCREEN: "fullscreen"
+    PARAM_USER: 'user',
+    PARAM_PASSWORD: 'password',
+    PARAM_USE_LOCAL_COPY: 'uselocalcopy',
+    PARAM_ELEMENT_HIGHLIGHT_IDS: 'highlightIds',
+    PARAM_LOCKED: 'locked',
+    PARAM_FULLSCREEN: 'fullscreen'
 };
 
 let _demoMode = false;
@@ -20,7 +23,7 @@ let _alreadyResetted = false;
  * sets many params to search params in the current URL
  * @param params an object containing key/value pairs to add
  */
-urlParamService.setParamsToSearchQuery = function(params = {}) {
+urlParamService.setParamsToSearchQuery = function (params = {}) {
     let queryParams = new URLSearchParams(location.search);
     for (let key of Object.keys(params)) {
         if (params[key]) {
@@ -30,13 +33,13 @@ urlParamService.setParamsToSearchQuery = function(params = {}) {
         }
     }
     setURLSearchParamsToURL(queryParams);
-}
+};
 
 /**
  * gets an object with keys/values of the search query params of the current url
  * @additionalParams object with additional params, which are added to the search query params
  */
-urlParamService.getSearchQueryParams = function(additionalParams = {}) {
+urlParamService.getSearchQueryParams = function (additionalParams = {}) {
     let params = new URLSearchParams(location.search);
 
     // Object.fromEntries polyfill https://stackoverflow.com/a/68655198/9219743
@@ -52,8 +55,7 @@ urlParamService.getSearchQueryParams = function(additionalParams = {}) {
     for (let key of Object.keys(paramObject)) {
         try {
             paramObject[key] = JSON.parse(paramObject[key]);
-        } catch (e) {
-        }
+        } catch (e) {}
     }
     return Object.assign(paramObject, additionalParams);
 };
@@ -64,11 +66,11 @@ urlParamService.isDemoMode = function () {
     return _demoMode;
 };
 
-urlParamService.isFullscreen = function(remove) {
+urlParamService.isFullscreen = function (remove) {
     return isSetAndNotFalse(urlParamService.params.PARAM_FULLSCREEN, remove);
 };
 
-urlParamService.isLocked = function(remove) {
+urlParamService.isLocked = function (remove) {
     return isSetAndNotFalse(urlParamService.params.PARAM_LOCKED, remove);
 };
 
@@ -91,19 +93,18 @@ urlParamService.shouldResetDatabase = function () {
     return shouldReset;
 };
 
-
 urlParamService.getParam = function (name) {
     return getParam(name);
-}
+};
 
-urlParamService.removeParam = function(name) {
+urlParamService.removeParam = function (name) {
     let searchParams = new URLSearchParams(window.location.search);
     searchParams.delete(name);
     setURLSearchParamsToURL(searchParams);
-}
+};
 
-function setURLSearchParamsToURL (searchParams) {
-    let questionMark = searchParams.size > 0 ? "?" : "";
+function setURLSearchParamsToURL(searchParams) {
+    let questionMark = searchParams.size > 0 ? '?' : '';
     history.replaceState(null, null, `${location.pathname}${questionMark}${searchParams.toString()}${location.hash}`);
 }
 


### PR DESCRIPTION
## Summary
- allow loading grid sets via `gridset_url` parameter
- document how to import grid sets from external URLs
- support `user`, `password` and `uselocalcopy` parameters to share online users or clone them offline

## Testing
- `npm test`
- `npx prettier -w src/js/service/urlParamService.js src/js/mainScript.js docs/documentation_user/04_navigation-overview.md`
