### PR TITLE
feat: confirm before replacing grids on import

### DIFF
--- a/app/lang/i18n.en.json
+++ b/app/lang/i18n.en.json
@@ -35,6 +35,7 @@
   "WEBRADIO_ACTION_VOLDOWN": "Radio volume down",
   "CONFIRM_IMPORT_BACKUP": "Caution: This action will delete the existing configuration and replace it with the data from file \"{0}\". Continue?",
   "CONFIRM_DELETE_GRID": "Do you really want to delete the grid \"{0}\"?",
+  "CONFIRM_REPLACE_EXISTING_GRID": "Grid \"{0}\" already exists. Replace existing grid?",
   "CONFIRM_DELETE_DICT": "Do you really want to delete the dictionary \"{0}\"?",
   "CONFIRM_RESET_DB": "Do you really want to reset to default configuration? All current grids will be deleted!",
   "CONFIRM_DELETE_ALL_ELEMS": "Do you really want to delete all elements of the current grid?",

--- a/app/lang/i18n.es.json
+++ b/app/lang/i18n.es.json
@@ -35,6 +35,7 @@
   "WEBRADIO_ACTION_VOLDOWN": "Bajar volumen de la radio",
   "CONFIRM_IMPORT_BACKUP": "Atención: Esta acción eliminará la configuración existente y la reemplazará con los datos del archivo \"{0}\". ¿Continuar?",
   "CONFIRM_DELETE_GRID": "¿Realmente desea eliminar el tablero \"{0}\"?",
+  "CONFIRM_REPLACE_EXISTING_GRID": "El tablero \"{0}\" ya existe. ¿Desea reemplazarlo?",
   "CONFIRM_DELETE_DICT": "¿Realmente desea eliminar el diccionario \"{0}\"?",
   "CONFIRM_RESET_DB": "¿Realmente desea restablecer la configuración predeterminada? ¡Se eliminarán todos los tableros existentes!",
   "CONFIRM_DELETE_ALL_ELEMS": "¿Realmente desea eliminar todas las celdas del tablero actual?",


### PR DESCRIPTION
## Summary
- warn about grids with duplicate names when importing custom data and let user replace or rename
- add translations for new confirmation dialog

## Testing
- `npm test`

